### PR TITLE
fix(test):add register client in some rule tests and remove register rule in a interchain test

### DIFF
--- a/tester/bxh_tester/case007_interchain_test.go
+++ b/tester/bxh_tester/case007_interchain_test.go
@@ -88,7 +88,6 @@ func (suite *Snake) TestHandleIBTPShouldSucceed() {
 func (suite *Snake) TestHandleIBTPWithNonexistentFrom() {
 	kA, kB, from, to := suite.prepare()
 	suite.RegisterAppchain(kB, "fabric")
-	suite.RegisterRule(kA, "./testdata/simple_rule.wasm")
 
 	suite.client.SetPrivateKey(kA)
 	ib := &pb.IBTP{From: from.Hex(), To: to.Hex(), Index: 1, Timestamp: time.Now().UnixNano()}

--- a/tester/bxh_tester/case008_rule_test.go
+++ b/tester/bxh_tester/case008_rule_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func (suite *Snake) TestRegisterRuleShouldSucceed() {
+	suite.RegisterAppchain(suite.pk, "hyperchain")
+
 	contract, err := ioutil.ReadFile("./testdata/simple_rule.wasm")
 	suite.Nil(err)
 
@@ -24,6 +26,8 @@ func (suite *Snake) TestRegisterRuleShouldSucceed() {
 }
 
 func (suite *Snake) TestAuditRuleShouldSucceed() {
+	suite.RegisterAppchain(suite.pk, "hyperchain")
+
 	contract, err := ioutil.ReadFile("./testdata/simple_rule.wasm")
 	suite.Nil(err)
 
@@ -81,6 +85,7 @@ func (suite *Snake) TestGetFabricRuleAddressShouldSucceed() {
 }
 
 func (suite *Snake) TestRegisterUnexistedWasmRuleShouldFail() {
+	suite.RegisterAppchain(suite.pk, "hyperchain")
 	contractAddr := "0x1234"
 	args := []*pb.Arg{
 		rpcx.String(suite.from.String()),
@@ -103,6 +108,6 @@ func (suite *Snake) TestRegisterUnexistedAppchainShouldFail() {
 		rpcx.String(contractAddr.String()),
 	}
 	res, err := suite.client.InvokeBVMContract(rpcx.RuleManagerContractAddr, "RegisterRule", args...)
-	suite.NotNil(err)
+	suite.Nil(err)
 	suite.True(res.Status == pb.Receipt_FAILED)
 }


### PR DESCRIPTION
1. Because the registration of rule will check whether the application chain is registered and the client is an unregistered application chain ，some rule tests need register client to register rule or audit rule.
2. Because the registration of rule will check whether the application chain is registered and the from appchain in TestHandleIBTPWithNonexistentFrom is unregistered，it doesn't need register rule .
3. Fixed an error judgment in a test case in rule test, because no error will be reported when the test case fails, only the failed state will be returned.