### PR TITLE
fix(cmd/premo): add a judgement about whether concurrent is bigger than tps

### DIFF
--- a/cmd/premo/test.go
+++ b/cmd/premo/test.go
@@ -77,6 +77,10 @@ func benchmark(ctx *cli.Context) error {
 		Rule:        contract,
 	}
 
+	if config.Concurrent > config.TPS {
+		return fmt.Errorf("error: concurrent should be less than tps")
+	}
+
 	broker, err := bitxhub.New(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
add a judgement about whether concurrent is bigger than tps