### PR TITLE
fix(bitxhub): fix invalid interchain tx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,13 @@ module github.com/meshplus/premo
 go 1.13
 
 require (
-	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
 	github.com/Rican7/retry v0.1.0
-	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/cheynewallace/tabby v1.1.0
 	github.com/cloudflare/cfssl v0.0.0-20190409034051-768cd563887f // indirect
 	github.com/coreos/etcd v3.3.18+incompatible
 	github.com/ethereum/go-ethereum v1.9.18
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
-	github.com/gobuffalo/envy v1.9.0 // indirect
 	github.com/gobuffalo/packd v1.0.0
 	github.com/gobuffalo/packr v1.30.1
 	github.com/golangci/golangci-lint v1.23.0 // indirect
@@ -29,8 +26,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.2-0.20200724220135-c650ae9fa103 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
-	github.com/rogpeppe/go-internal v1.5.2 // indirect
-	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v2.20.5+incompatible
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/viper v1.6.1

--- a/internal/bitxhub/bee.go
+++ b/internal/bitxhub/bee.go
@@ -277,7 +277,7 @@ func (bee *bee) sendInterchainTx(i uint64) error {
 		Nonce:     rand.Int63(),
 	}
 
-	if err := tx.Sign(bee.privKey); err != nil {
+	if err := tx.Sign(bee.xprivKey); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When run "premo test -c 1 -t 1 --type interchain" command,
it will get invalid signature error from bitxhub.
The "from" address of interchain tx is not dedrived from bee.xprivKey