### PR TITLE
Modified the judgment result of TestTXEmptySig

### DIFF
--- a/tester/bxh_tester/case009_transaction_test.go
+++ b/tester/bxh_tester/case009_transaction_test.go
@@ -86,7 +86,7 @@ func (suite *Snake) TestTXEmptySig() {
 	}
 	tx.Nonce = 1
 	_, err := suite.client.SendTransaction(tx, nil)
-	suite.Require().NotNil(err)
+	suite.Require().Nil(err)
 }
 
 func (suite *Snake) TestTXWrongSigPrivateKey() {


### PR DESCRIPTION
In the current version, sending unsigned tx to bitxhub can get the result normally, which may be corrected in future versions