### PR TITLE
fix(bitxhub): fix sending tx with same admin key error

### DIFF
--- a/internal/bitxhub/bitxhub.go
+++ b/internal/bitxhub/bitxhub.go
@@ -63,7 +63,7 @@ func New(config *Config) (*Broker, error) {
 		go func() {
 			defer wg.Done()
 
-			bee, err := NewBee(config.TPS/config.Concurrent, config.BitxhubAddr, config)
+			bee, err := NewBee(config.TPS/config.Concurrent, config)
 			if err != nil {
 				logger.Error(err)
 				return
@@ -89,7 +89,7 @@ func New(config *Config) (*Broker, error) {
 	client, err := rpcx.New(
 		rpcx.WithNodesInfo(node0),
 		rpcx.WithLogger(cfg.logger),
-		rpcx.WithPrivateKey(bees[0].xprivKey),
+		rpcx.WithPrivateKey(bees[0].adminPrivKey),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1. use the same admin key to send transfer tx in multiple bees will cause
the the same account to send tx with same nonce multiple times.
2. send transfer tx with zero amount will cause tx payload to be nil
when it arrived at bitxhub because all fields of TransactionData is default value.